### PR TITLE
Enhance Cassandra connection configuration

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,14 @@ spring.application.name=wick
 # Cassandra Configuration
 spring.cassandra.contact-points=localhost
 spring.cassandra.port=9042
-spring.cassandra.keyspace-name=wick
-spring.cassandra.schema-action=CREATE_IF_NOT_EXISTS
 spring.cassandra.local-datacenter=datacenter1
+spring.cassandra.schema-action=CREATE_IF_NOT_EXISTS
+spring.cassandra.keyspace-name=wick
+spring.cassandra.connection.connect-timeout=30s
+spring.cassandra.connection.init-query-timeout=30s
+spring.cassandra.request.timeout=30s
+spring.cassandra.request.consistency=LOCAL_ONE
+spring.cassandra.connection.reconnect-on-init=true
+spring.cassandra.connection.max-requests-per-connection=32768
+spring.cassandra.connection.pool.local.size=4
+spring.cassandra.connection.pool.remote.size=1


### PR DESCRIPTION
- Increase connection timeouts from 10s to 30s for better stability
- Add connection pool settings optimized for single-node setup
- Configure reconnect-on-init for reliable connection handling
- Set maximum requests per connection to 32768
- Add LOCAL_ONE consistency level for single-node environment
- Reorder properties for better readability

These changes improve connection reliability and reduce transient warnings
during application startup.