### PR TITLE
Add secondary indexes for user queries

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,8 @@ spring.cassandra.connection.reconnect-on-init=true
 spring.cassandra.connection.max-requests-per-connection=32768
 spring.cassandra.connection.pool.local.size=4
 spring.cassandra.connection.pool.remote.size=1
+spring.cassandra.schema-action=CREATE_IF_NOT_EXISTS
+spring.cassandra.schema-creation-locations=classpath:schema.cql
 
 # Security Configuration
 spring.security.user.name=admin

--- a/src/main/resources/schema.cql
+++ b/src/main/resources/schema.cql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS wick.users (
+    id uuid PRIMARY KEY,
+    username text,
+    email text,
+    password_hash text,
+    first_name text,
+    last_name text,
+    phone_number text,
+    created_at timestamp,
+    last_login timestamp,
+    enabled boolean,
+    role text
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_username ON wick.users (username);
+CREATE INDEX IF NOT EXISTS idx_users_email ON wick.users (email); 


### PR DESCRIPTION
- Create secondary index on username column for efficient user lookups
- Create secondary index on email column for email-based queries
- Add schema.cql file for documentation and future reference
- Fix "ALLOW FILTERING" error in user registration/login flow

This change resolves the Cassandra query performance issue by adding
proper indexes for username and email lookups, allowing efficient
user authentication and registration without requiring ALLOW FILTERING.