### PR TITLE
Chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,28 @@
+# Maven build output
+/target/
+
+# Logs
+*.log
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# IntelliJ IDEA
+.idea/
+*.iml
+
+# VS Code
+.vscode/
+
+# Deployment artifacts
+/deploy/
+wick-backend.zip
+
+# Environment files
+.env
+
 HELP.md
-target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
@@ -12,12 +35,6 @@ target/
 .settings
 .springBeans
 .sts4-cache
-
-### IntelliJ IDEA ###
-.idea
-*.iws
-*.iml
-*.ipr
 
 ### NetBeans ###
 /nbproject/private/


### PR DESCRIPTION
Chore: add .gitignore to exclude build artifacts, IDE files, and deployment artifacts